### PR TITLE
SCPI compliant comma separated lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2025-09-03
+
+### Changed
+
+- Set application organization name from `HEPHY` to `MBI` (previous settings will be lost).
+
 ## [0.5.0] - 2025-09-01
 
 ### Added
@@ -56,7 +62,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for Hydra controller.
 - Support for Corvus controller.
 
-[unreleased]: https://github.com/hephy-dd/table-control/compare/v0.5.0...HEAD
+[unreleased]: https://github.com/hephy-dd/table-control/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/hephy-dd/table-control/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/hephy-dd/table-control/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/hephy-dd/table-control/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/hephy-dd/table-control/compare/v0.2.0...v0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- SCPI compliant comma separated argument lists (#11).
+- Renamed SCPI command `ZLIMit:ENABled?"` to compliant form `ZLIMit:ENABle?` (#11).
 - Set application organization name from `HEPHY` to `MBI` (previous settings will be lost).
 
 ## [0.5.0] - 2025-09-01

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include README.md
 include LICENSE
 include CHANGELOG.md
+include CONTRIBUTING.md
 include tox.ini
 
 include pyinstaller/*

--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ Make sure to enable and configure the SCPI socket in the application preferences
 |--------|------------|--------|
 |`*IDN?` | application identity | `*IDN?` -> `table-control v0.1.0` |
 |`*CLS` | clears error stack | `*CLS` |
-|`[:]POSition?` | get position | `POS?` -> `0.000 0.000 0.000` |
-|`[:]CALibration[:STATe]?` | get calibration | `CAL?` -> `3 3 3` (`1`=cal, `2`=rm, `3`=cal+rm) |
+|`[:]POSition?` | get position | `POS?` -> `0.000,0.000,0.000` |
+|`[:]CALibration[:STATe]?` | get calibration | `CAL?` -> `3,3,3` (`1`=cal, `2`=rm, `3`=cal+rm) |
 |`[:]MOVE[:STATe]?` | is moving? | `MOVE?` -> `1` |
-|`[:]MOVE:RELative <POS>` | 3-axis relative move | `MOVE:REL 0 0 4.200` |
-|`[:]MOVE:ABSolute <POS>` | 3-axis absolute move | `MOVE:ABS 10.000 20.000 2.000` |
+|`[:]MOVE:RELative <POS>` | 3-axis relative move | `MOVE:REL 0,0,4.200` |
+|`[:]MOVE:ABSolute <POS>` | 3-axis absolute move | `MOVE:ABS 10.000,20.000,2.000` |
 |`[:]MOVE:ABORT` | abort a movement | `MOVE:ABORT` |
 |`[:]ZLIMit[:VALue]?` | get Z limit value | `ZLIM?` -> `2.000` |
-|`[:]ZLIMit:ENABled?` | is Z limit enabled? | `ZLIM:ENAB?` -> `1` |
+|`[:]ZLIMit:ENABle?` | is Z limit enabled? | `ZLIM:ENAB?` -> `1` |
 |`[:]SYStem:ERRor[:NEXT]?` | next error on stack | `SYS:ERR?` -> `0,"no error"` |
 |`[:]SYStem:ERRor:COUNt?` | size of error stack | `SYS:ERR:COUN?` -> `0` |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "table-control"
-version = "0.5.0"
+version = "0.6.0"
 authors = [
     {name = "Bernhard Arnold", email = "bernhard.arnold@oeaw.ac.at"}
 ]

--- a/src/table_control/gui/application.py
+++ b/src/table_control/gui/application.py
@@ -13,8 +13,8 @@ class Application:
         self.app = QtWidgets.QApplication(sys.argv)
         self.app.setApplicationName(APP_NAME)
         self.app.setApplicationVersion(APP_VERSION)
-        self.app.setOrganizationName("HEPHY")
-        self.app.setOrganizationDomain("hephy.at")
+        self.app.setOrganizationName("MBI")
+        self.app.setOrganizationDomain("mbi.oeaw.ac.at")
         self.app.setApplicationDisplayName(f"{APP_TITLE} {APP_VERSION}")
         self.app.setWindowIcon(load_icon("table_control.svg"))
 

--- a/src/table_control/gui/controller.py
+++ b/src/table_control/gui/controller.py
@@ -235,7 +235,7 @@ class QueryPositionCommand(Command):
 class QueryCalibrationCommand(Command):
     def __call__(self, context) -> None:
         x, y, z = context.driver.calibration_state()
-        context.set_calibration(x, y, z)
+        context.set_calibration(int(x), int(y), int(z))
 
 
 @dataclass(slots=True)

--- a/src/table_control/plugins/scpi_socket.py
+++ b/src/table_control/plugins/scpi_socket.py
@@ -11,7 +11,7 @@ Supported SCPI commands:
 [:]MOVE:ABSolute <POS>     3-axis absolute move
 [:]MOVE:ABORT              abort a movement
 [:]ZLIMit[:VALue]?         get Z limit value
-[:]ZLIMit:ENABled?         is Z limit enabled?
+[:]ZLIMit:ENABle?          is Z limit enabled?
 [:]SYStem:ERRor[:NEXT]?    next error on stack
 [:]SYStem:ERRor:COUNt?     size of error stack
 
@@ -200,12 +200,12 @@ class SocketServer:
         # [:]POSition[:STATe]?
         if re.match(r"^\:?pos(ition)?(\:stat(e)?)?\?$", command):
             x, y, z = self.table.position()
-            return f"{x:.3f} {y:.3f} {z:.3f}"
+            return f"{x:.3f},{y:.3f},{z:.3f}"
 
         # [:]CALibration[:STATe]?
         if re.match(r"^\:?cal(ibration)?(\:stat(e)?)?\?$", command):
             x, y, z = self.table.calibration()
-            return f"{x:d} {y:d} {z:d}"
+            return f"{x:d},{y:d},{z:d}"
 
         # [:]MOVE[:STATe]?
         if re.match(r"^\:?move(\:stat(e)?)?\?$", command):
@@ -215,7 +215,8 @@ class SocketServer:
         # [:]MOVE:RELative X Y Z
         if re.match(r"^\:?move\:rel(ative)?$", command):
             try:
-                _, dx, dy, dz = message.split()
+                _, args = message.split(maxsplit=1)
+                dx, dy, dz = args.split(",")
                 self.table.move_relative(float(dx), float(dy), float(dz))
             except Exception:
                 self.error_stack.append((101, "invalid attributes"))
@@ -225,7 +226,8 @@ class SocketServer:
         # [:]MOVE:ABSolute X Y Z
         if re.match(r"^\:?move\:abs(olute)?$", command):
             try:
-                _, x, y, z = message.split()
+                _, args = message.split(maxsplit=1)
+                x, y, z = args.split(",")
                 self.table.move_absolute(float(x), float(y), float(z))
             except Exception:
                 self.error_stack.append((101, "invalid attributes"))
@@ -233,7 +235,7 @@ class SocketServer:
             return None
 
         # [:]ZLIMit:ENAbled?
-        if re.match(r"^\:?zlim(it)?\:enab(led)?\?$", command):
+        if re.match(r"^\:?zlim(it)?\:enab(le)?\?$", command):
             enabled = self.table.z_limit_enabled
             return "1" if enabled else "0"
 


### PR DESCRIPTION
Use commas as separators for SCPI parameters and lists:

Examples:
-  `MOVE:ABS 1.000 2.000 3.000` should be `MOVE:ABS 1.000,2.000,3.000`
- `POS?` returns `0.000 1.000 2.000` but should be `0.000,1.000,2.000`

Also SCPI keyword convention for `ZLIMit:ENABled` should be `ZLIMit:ENABle`.

These changes make the command set more consistent with the SCPI 1999.0 specification and will improve interoperability with generic SCPI clients.

Also the application organization name and domain is updated (this is reasonable at this early point of development).

Note: these are interface breaking changes.